### PR TITLE
VATRP-1271: There are two ways to change encrytion: Settings > Genera…

### DIFF
--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml
@@ -153,7 +153,7 @@
                    HorizontalAlignment="Left" Name="TransportLabel">
                 </Label>
                 <ComboBox Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="2" x:Name="TransportComboBox" FontSize="14" Margin="0,3,0,3" Width="120" Height="24" 
-                           VerticalAlignment="Center" HorizontalAlignment="Left" SelectionChanged="OnTransportChanged">
+                           VerticalAlignment="Center" HorizontalAlignment="Left" SelectionChanged="OnTransportChanged" Visibility="Collapsed">
                     <TextBlock >TCP</TextBlock>
                     <TextBlock >TLS</TextBlock>
                 </ComboBox>

--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
@@ -100,6 +100,9 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             ProxyLabel.Visibility = visibleSetting;
             ProxyTextBox.Visibility = visibleSetting;
 
+            TransportLabel.Visibility = visibleSetting;
+            TransportComboBox.Visibility = visibleSetting;
+
             OutboundProxyLabel.Visibility = visibleSetting;
             OutboundProxyCheckbox.Visibility = visibleSetting;
 
@@ -262,8 +265,12 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             if (App.CurrentAccount != null)
             {
                 bool isChanged = false;
-                
-                App.CurrentAccount.ProxyPort = port;
+
+                if (App.CurrentAccount.ProxyPort != port)
+                {
+                    App.CurrentAccount.ProxyPort = port;
+                    isChanged = true;
+                }
                 if (ValueChanged(App.CurrentAccount.AuthID, UserIdTextBox.Text))
                 {
                     App.CurrentAccount.AuthID = UserIdTextBox.Text;


### PR DESCRIPTION
…l > SIP Encryption Checkbox, and (Advanced) Settings > Transport. Once we have the fix for VATRP-814 then these should be working great.

Sending this Pull Request so that we can make sure that everything works with Shareef's fix. 

Note: there is not, as of yet, anything in this source that will update the port for tls. Waiting to get the relevant fix from 814 before making such a change. 
