### PR TITLE
VATRP-740: This should complete the TLS implementation for Windows. I…

### DIFF
--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsCtrl.xaml.cs
@@ -54,53 +54,39 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             BaseUnifiedSettingsPanel.EnableSuperSettings = false;
 
             _mainPanel = new UnifiedSettingsMainCtrl();
-            _allPanels.Add(_mainPanel);
-            _mainPanel.ContentChanging += HandleContentChanging;
-            _mainPanel.AccountChangeRequested += HandleAccountChangeRequested;
             _mainPanel.ShowSettingsUpdate += HandleShowSettingsUpdate;
+            InitializePanelAndEvents(_mainPanel);
 
             _generalPanel = new UnifiedSettingsGeneralCtrl();
-            _allPanels.Add(_generalPanel);
-            _generalPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_generalPanel);
 
             _audioVideoPanel = new UnifiedSettingsAudioVideoCtrl();
-            _allPanels.Add(_audioVideoPanel);
-            _audioVideoPanel.ContentChanging += HandleContentChanging;
-            _audioVideoPanel.AccountChangeRequested += HandleAccountChangeRequested;
+            InitializePanelAndEvents(_audioVideoPanel);
 
             _themePanel = new UnifiedSettingsThemeCtrl();
-            _allPanels.Add(_themePanel);
-            _themePanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_themePanel);
 
             _textPanel = new UnifiedSettingsTextCtrl();
-            _allPanels.Add(_textPanel);
-            _textPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_textPanel);
 
             _summaryPanel = new UnifiedSettingsSummaryCtrl();
-            _allPanels.Add(_summaryPanel);
-            _summaryPanel.ContentChanging += HandleContentChanging;
             _summaryPanel.ShowSettingsUpdate += HandleShowSettingsUpdate;
+            InitializePanelAndEvents(_summaryPanel);
 
             _audioSettingsPanel = new UnifiedSettingsAudioCtrl();
-            _allPanels.Add(_audioSettingsPanel);
-            _audioSettingsPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_audioSettingsPanel);
 
             _videoSettingsPanel = new UnifiedSettingsVideoCtrl();
-            _allPanels.Add(_videoSettingsPanel);
-            _videoSettingsPanel.AccountChangeRequested += HandleAccountChangeRequested;
-            _videoSettingsPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_videoSettingsPanel);
 
             _callSettingsPanel = new UnifiedSettingsCallCtrl();
-            _allPanels.Add(_callSettingsPanel);
-            _callSettingsPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_callSettingsPanel);
 
             _networkSettingsPanel = new UnifiedSettingsNetworkCtrl();
-            _allPanels.Add(_networkSettingsPanel);
-            _networkSettingsPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_networkSettingsPanel);
 
             _advancedSettingsPanel = new UnifiedSettingsAdvancedCtrl();
-            _allPanels.Add(_advancedSettingsPanel);
-            _advancedSettingsPanel.ContentChanging += HandleContentChanging;
+            InitializePanelAndEvents(_advancedSettingsPanel);
 
             _currentContent = _mainPanel;
 #if DEBUG
@@ -109,6 +95,20 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             HandleShowSettingsUpdate(UnifiedSettings_LevelToShow.Normal, true);
 #endif
             UpdateContentInUI();
+        }
+
+        private void InitializePanelAndEvents(BaseUnifiedSettingsPanel panel)
+        {
+            if (panel == null)
+                return;
+            
+            if (!_allPanels.Contains(panel))
+            {
+                _allPanels.Add(panel);
+            }
+
+            panel.ContentChanging += HandleContentChanging;
+            panel.AccountChangeRequested += HandleAccountChangeRequested;
         }
 
         public void Initialize()

--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsGeneralCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsGeneralCtrl.xaml.cs
@@ -135,6 +135,7 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
                 if (!App.CurrentAccount.Transport.Equals("TCP"))
                 {
                     App.CurrentAccount.Transport = "TCP";
+                    App.CurrentAccount.ProxyPort = 25060;
                     changed = true;
                 }
             }
@@ -142,7 +143,8 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             {
                 if (!App.CurrentAccount.Transport.Equals("TLS"))
                 {
-                    App.CurrentAccount.Transport = "TLS"; 
+                    App.CurrentAccount.Transport = "TLS";
+                    App.CurrentAccount.ProxyPort = 25061;
                     changed = true;
                 }
             }

--- a/VATRP.App/MainWindow.Events.cs
+++ b/VATRP.App/MainWindow.Events.cs
@@ -476,6 +476,7 @@ namespace com.vtcsecure.ace.windows
 
 		private void OnRegistrationChanged(LinphoneRegistrationState state)
 		{
+//            LOG.Debug("MainWindow.Event:OnRegistrationChanged: registrationState = " + state.ToString());
 			if (this.Dispatcher.Thread != Thread.CurrentThread)
 			{
 				this.Dispatcher.BeginInvoke((Action)(() => this.OnRegistrationChanged(state)));

--- a/VATRP.App/MainWindow.xaml.cs
+++ b/VATRP.App/MainWindow.xaml.cs
@@ -270,7 +270,15 @@ namespace com.vtcsecure.ace.windows
             {
                 _linphoneService.Unregister(false);
             }
-            _linphoneService.Register();
+            else
+            {
+                // Liz E. - We do want this else here to prevent registration from being called twice. 
+                //  If we call unregister above, then after the app has finished unregistering, it will use the 
+                //  register requested flag to call Register. Otherwise, go on and call Register here. This
+                //  mechanism was previously put in place as a lock to make sure that we move through the states properly
+                //  befor calling register.
+                _linphoneService.Register();
+            }
         }
 
         private void UpdateMenuSettingsForRegistrationState()


### PR DESCRIPTION
…f the user selects SIP Encryption in the General Settings then this will force the port to a usable port (either 25060 or 25061, depending ont he setting). Also - LinphoneService now is checking the current  state to try to ensure that registration does not get call more than once. There is still the slight possibility of a race condition because we are woring with an outside dll, so the app is still responsible for moving with the states. Eg - wait for Unregister to complete prior to calling Register.
