### PR TITLE
 Add parameters to first time startup of the app

### DIFF
--- a/VATRP.App/Services/ServiceManager.cs
+++ b/VATRP.App/Services/ServiceManager.cs
@@ -457,6 +457,7 @@ namespace com.vtcsecure.ace.windows.Services
                 LinphoneService.FillCodecsList(App.CurrentAccount, CodecType.Video);
 
             LinphoneService.UpdateNetworkingParameters(App.CurrentAccount);
+            LinphoneService.configureFmtpCodec();
             ApplyAVPFChanges();
             ApplyDtmfOnSIPInfoChanges();
             ApplyMediaSettingsChanges();

--- a/VATRP.Core/Interfaces/ILinphoneService.cs
+++ b/VATRP.Core/Interfaces/ILinphoneService.cs
@@ -62,6 +62,7 @@ namespace VATRP.Core.Interfaces
         bool IsVideoEnabled(VATRPCall call);
         void UpdateMediaSettings(VATRPAccount account);
         bool UpdateNativeCodecs(VATRPAccount account, CodecType codecType);
+        void configureFmtpCodec();
         void FillCodecsList(VATRPAccount account, CodecType codecType);
         bool UpdateNetworkingParameters(VATRPAccount account);
         void SetAVPFMode(LinphoneAVPFMode mode);

--- a/VATRP.Core/Services/LinphoneService.cs
+++ b/VATRP.Core/Services/LinphoneService.cs
@@ -1325,23 +1325,7 @@ namespace VATRP.Core.Services
                 LOG.Info(string.Format("Removing Codec from configuration: {0} , Channels: {1} ", codec.CodecName, codec.Channels));
                 cfgCodecs.Remove(codec);
             }
-            var ptPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H263", 90000, -1);
-            if (ptPtr != IntPtr.Zero)
-            {
-                var payload = (PayloadType)Marshal.PtrToStructure(ptPtr, typeof(PayloadType));
-                payload.send_fmtp = "CIF=1;QCIF=1";
-                payload.recv_fmtp = "CIF=1;QCIF=1";
-                Marshal.StructureToPtr(payload, ptPtr, false);
-                LinphoneAPI.linphone_core_payload_type_enabled(linphoneCore, ptPtr);
-            }
-            ptPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H264", 90000, -1);
-            if (ptPtr != IntPtr.Zero)
-            {
-                var payload = (PayloadType)Marshal.PtrToStructure(ptPtr, typeof(PayloadType));
-                payload.recv_fmtp = "packetization-mode=1";
-                Marshal.StructureToPtr(payload, ptPtr, false);
-                LinphoneAPI.linphone_core_payload_type_enabled(linphoneCore, ptPtr);
-            }
+
             return retValue;
 	    }
 
@@ -1353,25 +1337,29 @@ namespace VATRP.Core.Services
             var linphoneCodecs = codecType == CodecType.Video ? _videoCodecs : _audioCodecs;
             cfgCodecs.Clear();
             cfgCodecs.AddRange(linphoneCodecs);
-             var ptPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H263", 90000, -1);
-            if (ptPtr != IntPtr.Zero)
-            {
-                var payload = (PayloadType)Marshal.PtrToStructure(ptPtr, typeof(PayloadType));
-                payload.send_fmtp = "CIF=1;QCIF=1";
-                payload.recv_fmtp = "CIF=1;QCIF=1";
-                Marshal.StructureToPtr(payload, ptPtr, false);
-                LinphoneAPI.linphone_core_payload_type_enabled(linphoneCore, ptPtr);
-            }
-            ptPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H264", 90000, -1);
-            if (ptPtr != IntPtr.Zero)
-            {
-                var payload = (PayloadType)Marshal.PtrToStructure(ptPtr, typeof(PayloadType));
-                payload.recv_fmtp = "packetization-mode=1";
-                Marshal.StructureToPtr(payload, ptPtr, false);
-                LinphoneAPI.linphone_core_payload_type_enabled(linphoneCore, ptPtr);
-            }
 	    }
 
+        public void configureFmtpCodec()
+        {
+            var h263PtPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H263", 90000, -1);
+            setFmtpSetting(h263PtPtr, "CIF=1;QCIF=1", "CIF=1;QCIF=1");
+            var h264PtPtr = LinphoneAPI.linphone_core_find_payload_type(linphoneCore, "H264", 90000, -1);
+            setFmtpSetting(h264PtPtr, null, "packetization-mode=1");
+        }
+        private void setFmtpSetting(IntPtr ptPtr, string sendFmtp, string recvFmtp)
+        {
+            if (ptPtr != IntPtr.Zero)
+            {
+                var payload = (PayloadType)Marshal.PtrToStructure(ptPtr, typeof(PayloadType));
+                if (recvFmtp != null)
+                     payload.recv_fmtp = recvFmtp;
+                if (sendFmtp != null)
+                    payload.send_fmtp = sendFmtp;
+                Marshal.StructureToPtr(payload, ptPtr, false);
+                LinphoneAPI.linphone_core_payload_type_enabled(linphoneCore, ptPtr);
+            }
+
+        }
 		private void LoadAudioCodecs()
 		{
             if (linphoneCore == IntPtr.Zero)


### PR DESCRIPTION
Updatenativecodec() gets called when the app data get filled already. 
So put the parameters in fill codec list so it get called when the data is empty
