### PR TITLE
VATRP-1643: Enable Video settings initializing properly. Note: Need t…

### DIFF
--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
@@ -63,6 +63,7 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
                         break;
                     }
                 }
+                this.EnableVideoCheckBox.IsChecked = App.CurrentAccount.EnableVideo;
             }
 
             this.EnableRTTCheckBox.IsChecked = ServiceManager.Instance.ConfigurationService.Get(Configuration.ConfSection.GENERAL,
@@ -413,8 +414,9 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             Console.WriteLine("Enable Video Clicked");
             if (App.CurrentAccount != null)
             {
-                bool enabled = EnableVideoCheckBox.IsChecked ?? false;
+                bool enabled = EnableVideoCheckBox.IsChecked ?? true;
                 App.CurrentAccount.EnableVideo = enabled;
+                ServiceManager.Instance.SaveAccountSettings();
                 OnAccountChangeRequested(Enums.ACEMenuSettingsUpdateType.VideoPolicyChanged);
             }                        
         }

--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsVideoCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsVideoCtrl.xaml.cs
@@ -243,8 +243,9 @@ Default value = 1
             if (enable != App.CurrentAccount.VideoAutomaticallyStart)
             {
                 App.CurrentAccount.VideoAutomaticallyStart = enable;
-                ServiceManager.Instance.ApplyMediaSettingsChanges();
                 ServiceManager.Instance.SaveAccountSettings();
+
+                OnAccountChangeRequested(Enums.ACEMenuSettingsUpdateType.VideoPolicyChanged);
             }
         }
 
@@ -257,8 +258,9 @@ Default value = 1
             if (enable != App.CurrentAccount.VideoAutomaticallyAccept)
             {
                 App.CurrentAccount.VideoAutomaticallyAccept = enable;
-                ServiceManager.Instance.ApplyMediaSettingsChanges();
                 ServiceManager.Instance.SaveAccountSettings();
+
+                OnAccountChangeRequested(Enums.ACEMenuSettingsUpdateType.VideoPolicyChanged);
             }
         }
         private void OnShowSelfView(object sender, RoutedEventArgs e)

--- a/VATRP.Core/Services/LinphoneService.cs
+++ b/VATRP.Core/Services/LinphoneService.cs
@@ -1138,8 +1138,8 @@ namespace VATRP.Core.Services
 			if (t_videoPolicyPtr != IntPtr.Zero)
 			{
 
-				LinphoneAPI.linphone_core_enable_video_capture(linphoneCore, true);
-				LinphoneAPI.linphone_core_enable_video_display(linphoneCore, true);
+				LinphoneAPI.linphone_core_enable_video_capture(linphoneCore, enable);
+				LinphoneAPI.linphone_core_enable_video_display(linphoneCore, enable);
 				LinphoneAPI.linphone_core_set_video_policy(linphoneCore, t_videoPolicyPtr);
 				Marshal.FreeHGlobal(t_videoPolicyPtr);
 			}


### PR DESCRIPTION
…o ensure that when we set the video policy in linphone the settings 'take' properly.

Setting also stored properly.
