### PR TITLE
VATRP-1509: hide avpf enable checkbox

### DIFF
--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
@@ -108,8 +108,8 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             OutboundProxyLabel.Visibility = visibleSetting;
             OutboundProxyCheckbox.Visibility = visibleSetting;
 
-            AvpfLabel.Visibility = visibleSetting;
-            AvpfCheckbox.Visibility = visibleSetting;
+//            AvpfLabel.Visibility = visibleSetting;
+//            AvpfCheckbox.Visibility = visibleSetting;
 
             PreferencesLabel.Visibility = visibleSetting;
 


### PR DESCRIPTION
Also - remove compiler defines that are forcing Enable AVPF to true in non-debug mode - the only time that the setting is being used is if the user goes and toggles the setting otherwise
