### PR TITLE
VATRP-1773: fix for crash on launch - enable video being set too earl…

### DIFF
--- a/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
+++ b/VATRP.App/CustomControls/UnifiedSettings/UnifiedSettingsMainCtrl.xaml.cs
@@ -414,8 +414,11 @@ namespace com.vtcsecure.ace.windows.CustomControls.UnifiedSettings
             if (App.CurrentAccount != null)
             {
                 bool enabled = EnableVideoCheckBox.IsChecked ?? false;
-                App.CurrentAccount.EnableVideo = enabled;
-                OnAccountChangeRequested(Enums.ACEMenuSettingsUpdateType.VideoPolicyChanged);
+                if (App.CurrentAccount.EnableVideo != enabled)
+                {
+                    App.CurrentAccount.EnableVideo = enabled;
+                    OnAccountChangeRequested(Enums.ACEMenuSettingsUpdateType.VideoPolicyChanged);
+                }
             }                        
         }
 

--- a/VATRP.Core/Services/LinphoneService.cs
+++ b/VATRP.Core/Services/LinphoneService.cs
@@ -1118,6 +1118,10 @@ namespace VATRP.Core.Services
 
         public void EnableVideo(bool enable, bool automaticallyInitiate, bool automaticallyAccept)
 		{
+            if ((linphoneCore == null) || (linphoneCore == IntPtr.Zero))
+            {
+                return;
+            }
             // if current account exists and we are enabling video, intialize initiate and accept vars to account. Otherwise go with previous
             //   implementation - based on enable.
             bool autoInitiate = enable;
@@ -1143,6 +1147,11 @@ namespace VATRP.Core.Services
 				LinphoneAPI.linphone_core_set_video_policy(linphoneCore, t_videoPolicyPtr);
 				Marshal.FreeHGlobal(t_videoPolicyPtr);
 			}
+            if ((callsDefaultParams == null) || (callsDefaultParams == IntPtr.Zero))
+            {
+                return;
+            }
+
 		}
 
         // Liz E: needed for unified settings


### PR DESCRIPTION
…y. added safety checks to prevent calls if not yet ready
