### PR TITLE
VATRP-3553: Modify default Provider labels to prevent duplicates. Do …

### DIFF
--- a/VATRP.App/CustomControls/ProviderLoginScreen.xaml
+++ b/VATRP.App/CustomControls/ProviderLoginScreen.xaml
@@ -12,6 +12,18 @@
             <Label x:Name="VatrpDefaultLabel" Content="Select Default VRS Provider" 
                    Foreground="{StaticResource AppMainBorderBrush}"
                    FontSize="16"  HorizontalAlignment="Center" Margin="0, 10,0, 0"/>
+            <Grid Margin="10, 0, 20,0" Name="InternetUnavailableGrid" Visibility="Collapsed">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="170"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Column="0" x:Name="InternetUnavailableLabel"  
+                   Foreground="{StaticResource AppMainBorderBrush}"
+                   FontSize="16"  HorizontalAlignment="Center" Margin="0, 0, 0, 0">
+                    <TextBlock Text="Unable to reach server. Please check your internet connection" TextAlignment="Center" TextWrapping="Wrap"/>
+                </Label>
+                <Button Content="Try Again" Grid.Column="1" FontSize="14" Height="25" Width="80"  Click="TryAgain_Click"/>
+            </Grid>
             <Grid Margin="20,5,20,5">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="85"/>

--- a/VATRP.App/CustomControls/ProviderLoginScreen.xaml.cs
+++ b/VATRP.App/CustomControls/ProviderLoginScreen.xaml.cs
@@ -40,7 +40,25 @@ namespace com.vtcsecure.ace.windows.CustomControls
 
         public void Initialize()
         {
-            InitializeToProvider("STL Test");
+            bool internetAvailable = NetworkUtility.IsCDNAvailable();
+            if (NetworkUtility.IsCDNAvailable())
+            {
+                InitializeToProvider("STL Test");
+                InternetUnavailableGrid.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                InternetUnavailableGrid.Visibility = Visibility.Visible;
+            }
+            ProviderComboBox.IsEnabled = internetAvailable;
+            LoginCmd.IsEnabled = internetAvailable;
+            TransportComboBox.IsEnabled = internetAvailable;
+            AuthIDBox.IsEnabled = internetAvailable;
+            LoginBox.IsEnabled = internetAvailable;
+            PasswdBox.IsEnabled = internetAvailable;
+            HostnameBox.IsEnabled = internetAvailable;
+            HostPortBox.IsEnabled = internetAvailable;
+            AutoLoginBox.IsEnabled = internetAvailable;
         }
 
         public void InitializeToProvider(string providerName)
@@ -100,6 +118,11 @@ namespace com.vtcsecure.ace.windows.CustomControls
                     }
                 }
             }
+        }
+
+        private void TryAgain_Click(object sender, RoutedEventArgs e)
+        {
+            Initialize();
         }
 
         private void OnForgotpassword(object sender, RequestNavigateEventArgs e)

--- a/VATRP.App/Services/ServiceManager.cs
+++ b/VATRP.App/Services/ServiceManager.cs
@@ -20,7 +20,8 @@ namespace com.vtcsecure.ace.windows.Services
 {
     internal class ServiceManager : ServiceManagerBase
     {
-        private const string CDN_DOMAIN_URL = "http://cdn.vatrp.net/domains.json";
+        public const string CDN_DOMAIN = "cdn.vatrp.net";
+        public const string CDN_DOMAIN_URL = "http://" + CDN_DOMAIN + "/domains.json";
 
         #region Members
         private static readonly ILog LOG = LogManager.GetLogger(typeof(ServiceManager));
@@ -475,7 +476,7 @@ namespace com.vtcsecure.ace.windows.Services
             {
                 return;
             }
-            string[] labels = { "Sorenson VRS", "Purple VRS", "ZVRS", "Convo Relay", "CAAG", "Global VRS" };
+            string[] labels = { "Sorenson", "Purple", "ZVRS", "Convo", "Global" };
             foreach (var label in labels)
             {
                 if (ProviderService.FindProvider(label) == null)

--- a/VATRP.App/Utilities/NetworkUtility.cs
+++ b/VATRP.App/Utilities/NetworkUtility.cs
@@ -1,0 +1,46 @@
+﻿using com.vtcsecure.ace.windows.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace com.vtcsecure.ace.windows.Utilities
+{
+    public static class NetworkUtility
+    {
+        public static string INTERNET_UNAVAILABLE = "Please check your network connection and try again.";
+
+        public static bool IsInternetAvailable()
+        {
+            try
+            {
+                // Liz E. - ToDo later - we may prefer to add a method that allows us to test if the cdn provider is available, and another to test if the 
+                //   domain for the provider is available. Note: Google will work ipv4 & ipv6
+                Dns.GetHostEntry("www.google.com"); //using System.Net;
+                return true;
+            }
+            catch (SocketException ex)
+            {
+                return false;
+            }
+        }
+
+        public static bool IsCDNAvailable()
+        {
+            try
+            {
+                // Liz E. - ToDo later - we may prefer to add a method that allows us to test if the cdn provider is available, and another to test if the 
+                //   domain for the provider is available. Note: Google will work ipv4 & ipv6
+                Dns.GetHostEntry(ServiceManager.CDN_DOMAIN); //using System.Net;
+                return true;
+            }
+            catch (SocketException ex)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/VATRP.App/VATRP.App.csproj
+++ b/VATRP.App/VATRP.App.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Utilities\JsonDeserializer.cs" />
     <Compile Include="Utilities\JsonException.cs" />
     <Compile Include="Utilities\JsonWebRequest.cs" />
+    <Compile Include="Utilities\NetworkUtility.cs" />
     <Compile Include="Utilities\ScreenSaverHelper.cs" />
     <Compile Include="Utilities\SRVLookup.cs" />
     <Compile Include="Utilities\TechnicalSupportInfoBuilder.cs" />


### PR DESCRIPTION
…not call for provider info if we do not have connection. Let the user know if there is no connection at login screen and prevent login attempt by disabling login. Provide mechanism for the user to try internet again once they have verified connection.
