### PR TITLE
VATRP-3588: Remove Show Messaging View from View menu

### DIFF
--- a/VATRP.App/MainWindow.xaml
+++ b/VATRP.App/MainWindow.xaml
@@ -79,7 +79,7 @@
                 <MenuItem x:Name="ShowSelfPreviewItem" Header="_Show Self Preview" IsCheckable="True" Background="{DynamicResource AppMainWindowBrush}" 
                           Foreground="White" Click="OnShowPreviewWindow" />
                 <MenuItem x:Name="ShowMessagingViewItem" Header="_Show Messaging View" IsCheckable="True" Background="{DynamicResource AppMainWindowBrush}" 
-                          Foreground="White" Click="OnShowMessagingWindow" IsEnabled="{Binding IsAccountLogged}"/>
+                          Foreground="White" Click="OnShowMessagingWindow" IsEnabled="{Binding IsAccountLogged}" Visibility="Collapsed"/>
 
                 <!--<MenuItem Header="_" Background="{DynamicResource AppMainWindowBrush}" Foreground="White"/>-->
 				<!--<MenuItem x:Name="DialpadItem" Header="_DialPad Window" IsCheckable="True" Background="{DynamicResource AppMainWindowBrush}" Foreground="White"/>-->


### PR DESCRIPTION
This is collapsed and hidden for now - the checkbox logic is being used in other areas, when there is more time and room for larger changes we can just make this a bool stored somewhere instead.
