### PR TITLE
VATRP-3600: Treat Registration Failure and registration none the same…

### DIFF
--- a/VATRP.App/MainWindow.Events.cs
+++ b/VATRP.App/MainWindow.Events.cs
@@ -739,13 +739,14 @@ ServiceManager.Instance.ContactService.FindContact(new ContactID(string.Format("
 			            ServiceManager.Instance.SoundService.PlayConnectionChanged(true);
 			        }
 					break;
-				case LinphoneRegistrationState.LinphoneRegistrationFailed:
+                case LinphoneRegistrationState.LinphoneRegistrationNone:
+                case LinphoneRegistrationState.LinphoneRegistrationFailed:
 					ServiceManager.Instance.SoundService.PlayConnectionChanged(false);
 			        _playRegisterNotify = true;
-                    if (signOutRequest || defaultConfigRequest)
-                    {
+                //    if (signOutRequest || defaultConfigRequest)
+                //    {
                         processSignOut = true;
-                    }
+                //    }
 					break;
 				case LinphoneRegistrationState.LinphoneRegistrationCleared:
 					


### PR DESCRIPTION
… as a log out. Return to the login window. With the PR for 3553 this will prompt if lost internet, as well.
